### PR TITLE
Update to current kakoune version

### DIFF
--- a/registers.kak
+++ b/registers.kak
@@ -1,23 +1,26 @@
 def list-registers -docstring 'populate the *registers* buffer with the content of registers' %{
   edit! -scratch *registers*
-  %sh{
+  evaluate-commands %sh{
     # empty scratch buffer
-    echo 'exec -no-hooks \%d'
+    echo 'exec \%d'
 
     # paste the content of each register on a separate line
     for reg in {'%','.','#','"','@','/','^','|',{a..z},{0..9}}; do
-      echo "exec -no-hooks 'i${reg}<space><esc>\"${reg}po<esc>'"
+      echo "exec 'i${reg}<space><esc>\"${reg}pGj<a-j>o<esc>'"
     done
 
     # hide empty registers (lines with less than 4 chars)
-    echo 'exec -no-hooks \%<a-s><a-K>.{4,}<ret>d<space>'
+    echo 'exec \%<a-s><a-K>.{4,}<ret>d<space>'
+
+    # make sure all registers are easily visible
+    echo 'exec gg'
   }
 }
 
 # beware, it wipes the content of reg x
 def info-registers -docstring 'populate an info box with the content of registers' %{
   list-registers
-  exec -save-regs \% '%"xyga'
+  exec -save-regs \%| '%<a-s>|cut<space>-c-30<ret>%"xyga'
   info -title registers -- %reg{x}
   set-register x ''
 }


### PR DESCRIPTION
It wasn't working on the most recent kakoune versions, so this should fix it.

Some additional fixes:
- it can now handle multi-line register content by concatenation
- very long register content is truncated for the info box