### PR TITLE
Fix posix compatibility and display of special registers

### DIFF
--- a/registers.kak
+++ b/registers.kak
@@ -27,10 +27,8 @@ def list-registers -docstring 'populate the *registers* buffer with the content 
 
 def info-registers -docstring 'populate an info box with the content of registers' %{
   list-registers
-  eval -save-regs x %{
-      try %{ exec -save-regs '%<a-s>s^.{30}\K[^\n]*<ret>"_c…<esc>' }
-      exec '%"xyga'
-      info -title registers -- %reg{x}
-  }
+  try %{ exec '%<a-s>s^.{30}\K[^\n]*<ret>c…<esc>' }
+  exec '%'
+  info -title registers -- %val{selection}
 }
 

--- a/registers.kak
+++ b/registers.kak
@@ -14,7 +14,7 @@ def list-registers -docstring 'populate the *registers* buffer with the content 
     for reg in '"' '@' '/' '^' '|' \
                a b c d e f g h i j k l m n o p q r s t u v w x y z \
                0 1 2 3 4 5 6 8 9; do
-      echo "exec 'i${reg}<space><esc>\"${reg}pGj<a-J>do<esc>'"
+      echo "exec 'i${reg}<esc>\"${reg}pGj<a-j>o<esc>'"
     done
 
     # hide empty registers (lines with less than 4 chars)

--- a/registers.kak
+++ b/registers.kak
@@ -1,11 +1,17 @@
 def list-registers -docstring 'populate the *registers* buffer with the content of registers' %{
+  declare-option -hidden str-list special_regs "%% %reg{percent}" ". %reg{dot}" "# %reg{hash}"
   edit! -scratch *registers*
   evaluate-commands %sh{
     # empty scratch buffer
     echo 'exec \%d'
 
-    # paste the content of each register on a separate line
-    for reg in '%' '.' '#' '"' '@' '/' '^' '|' \
+    # paste the content of each register on a separate line, first the special registers
+    eval set -- "$kak_quoted_opt_special_regs"
+    for line; do
+      echo "exec 'i${line}<ret><esc>'"
+    done
+
+    for reg in '"' '@' '/' '^' '|' \
                a b c d e f g h i j k l m n o p q r s t u v w x y z \
                0 1 2 3 4 5 6 8 9; do
       echo "exec 'i${reg}<space><esc>\"${reg}pGj<a-J>do<esc>'"
@@ -21,7 +27,7 @@ def list-registers -docstring 'populate the *registers* buffer with the content 
 
 def info-registers -docstring 'populate an info box with the content of registers' %{
   list-registers
-  eval -save-regs \%x %{
+  eval -save-regs x %{
       try %{ exec -save-regs '%<a-s>s^.{30}\K[^\n]*<ret>"_c…<esc>' }
       exec '%"xyga'
       info -title registers -- %reg{x}

--- a/registers.kak
+++ b/registers.kak
@@ -5,7 +5,9 @@ def list-registers -docstring 'populate the *registers* buffer with the content 
     echo 'exec \%d'
 
     # paste the content of each register on a separate line
-    for reg in {'%','.','#','"','@','/','^','|',{a..z},{0..9}}; do
+    for reg in '%' '.' '#' '"' '@' '/' '^' '|' \
+               a b c d e f g h i j k l m n o p q r s t u v w x y z \
+               0 1 2 3 4 5 6 8 9; do
       echo "exec 'i${reg}<space><esc>\"${reg}pGj<a-j>o<esc>'"
     done
 

--- a/registers.kak
+++ b/registers.kak
@@ -8,7 +8,7 @@ def list-registers -docstring 'populate the *registers* buffer with the content 
     for reg in '%' '.' '#' '"' '@' '/' '^' '|' \
                a b c d e f g h i j k l m n o p q r s t u v w x y z \
                0 1 2 3 4 5 6 8 9; do
-      echo "exec 'i${reg}<space><esc>\"${reg}pGj<a-j>o<esc>'"
+      echo "exec 'i${reg}<space><esc>\"${reg}pGj<a-J>do<esc>'"
     done
 
     # hide empty registers (lines with less than 4 chars)

--- a/registers.kak
+++ b/registers.kak
@@ -19,11 +19,12 @@ def list-registers -docstring 'populate the *registers* buffer with the content 
   }
 }
 
-# beware, it wipes the content of reg x
 def info-registers -docstring 'populate an info box with the content of registers' %{
   list-registers
-  exec -save-regs \%| '%<a-s>|cut<space>-c-30<ret>%"xyga'
-  info -title registers -- %reg{x}
-  set-register x ''
+  eval -save-regs \%x %{
+      try %{ exec -save-regs '%<a-s>s^.{30}\K[^\n]*<ret>"_c…<esc>' }
+      exec '%"xyga'
+      info -title registers -- %reg{x}
+  }
 }
 

--- a/registers.kak
+++ b/registers.kak
@@ -1,16 +1,23 @@
 def list-registers -docstring 'populate the *registers* buffer with the content of registers' %{
-  declare-option -hidden str-list special_regs "%% %reg{percent}" ". %reg{dot}" "# %reg{hash}"
+  # store special registers in z, save original value in option
+  declare-option -hidden str-list z_reg %reg{z}
+  set-register z "%% %reg{percent}" ". %reg{dot}" "# %reg{hash}"
   edit! -scratch *registers*
   evaluate-commands %sh{
     # empty scratch buffer
     echo 'exec \%d'
 
-    # paste the content of each register on a separate line, first the special registers
-    eval set -- "$kak_quoted_opt_special_regs"
-    for line; do
-      echo "exec 'i${line}<ret><esc>'"
-    done
+    # paste the content of each register on a separate line
+    # first the special registers, paste then add newlines
+    echo "exec '\"z<a-p>a<ret><esc>_'"
+    # join multiline register contents
+    echo "try %{ exec 's\\\\n<ret>r<space>' }"
+    echo "exec 'geo<esc>'"
 
+    # restore original z register
+    echo 'set-register z %opt{z_reg}'
+
+    # paste regular registers, also join multiline contents
     for reg in '"' '@' '/' '^' '|' \
                a b c d e f g h i j k l m n o p q r s t u v w x y z \
                0 1 2 3 4 5 6 8 9; do


### PR DESCRIPTION
Hi, I recently came across this plugin which I think is very useful and informative, especially for newer users. I had some issues running it with my `sh` (which is `dash` in Debian) and made a fix for that. Then I fixed a few other issues (although getting them to work properly took me an embarassing amount time). To sum up, this PR has a few fixes and improvements:
- Avoid using brace expansions due to POSIX compatibility issues
- Display correct values for the registers `%`, `.` and `#` at the time of command invocation, rather than their values for the display buffer `*registers*`
- Avoid clobbering the `x` register in `info-registers`
- Avoid shelling out for truncation using `cut`, use native selections instead and add `…` to indicate truncation