### PR TITLE
Delete scratch buffer when showing infobox

### DIFF
--- a/registers.kak
+++ b/registers.kak
@@ -36,6 +36,8 @@ define-command info-registers -docstring 'populate an info box with the content 
   list-registers
   try %{ execute-keys '%<a-s>s^.{30}\K[^\n]*<ret>c…<esc>' }
   execute-keys '%'
-  info -title registers -- %val{selection}
+  declare-option -hidden str-list reg_info %val{selection}
+  delete-buffer
+  info -title registers -- %opt{reg_info}
 }
 


### PR DESCRIPTION
Should fix #5, but if this not possible due to licensing (I literally copied these 3 lines from the given link), then please don't accept

Source of changes:
https://github.com/forbesmyester/dotfiles/blob/e361f6f75fbf072f177b2f1a2cc1d8f836852073/kak/.config/kak/kakrc#L125-L133